### PR TITLE
add default pg schema

### DIFF
--- a/migo.go
+++ b/migo.go
@@ -26,6 +26,7 @@ type gormMigration struct {
 
 var DefaultOptions *Options = &Options{
 	Options: *gormigrate.DefaultOptions,
+	PgSchema: "public",
 }
 
 type Options struct {
@@ -34,7 +35,7 @@ type Options struct {
 }
 
 func (o Options) WithPgSchema(pgschema string) *Options {
-	d := DefaultOptions
+	d := &o
 	d.PgSchema = pgschema
 	return d
 }


### PR DESCRIPTION
### Small improvement 
This is not a breaking change, we just make the default pgschema "public" instead of an empty string, in case the user didn't use the WithPgSchema function